### PR TITLE
remove helpers:pinGitHubActionDigests

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -2,8 +2,7 @@
   extends: [
     "config:base",
     ":disableRateLimiting",
-    ":preserveSemverRanges",
-    "helpers:pinGitHubActionDigests"
+    ":preserveSemverRanges"
   ],
   lockFileMaintenance: {
     enabled: true,


### PR DESCRIPTION
With this default config focused on reducing noise, this helper `helpers:pinGitHubActionDigests` was creating a bit too much noise

Here is an example: https://github.com/mainmatter/ember-asset-size-action/pull/52

If we need to pin actions to their sha then we can do this on a case-by-case basis per repo 👍 