### PR TITLE
chore(deps): move renovate config from ESA

### DIFF
--- a/ember-addon.json5
+++ b/ember-addon.json5
@@ -1,0 +1,25 @@
+{
+  "extends": [
+    "github>mainmatter/renovate-config:default.json5",
+    ":pinOnlyDevDependencies"
+  ],
+  "packageRules": [
+    {
+      "groupName": "Ember Testing",
+      "matchPackageNames": [
+        "@ember/test-helpers",
+        "ember-qunit",
+        "qunit",
+        "qunit-dom",
+        "ember-try",
+      ],
+    },
+    {
+      "groupName": "Ember Fastboot",
+      "matchPackageNames": [
+        "ember-cli-fastboot",
+        "ember-cli-fastboot-testing",
+      ],
+    }
+  ]
+}


### PR DESCRIPTION
- Moves config from https://github.com/mainmatter/ember-simple-auth into (hopefully) common, shared location for our addons.