### PR TITLE
chore(ember-addon): add devDependencies automerging

### DIFF
--- a/automerge-dev.json5
+++ b/automerge-dev.json5
@@ -1,0 +1,14 @@
+{
+  packageRules: [
+    {
+      "extends": [
+        ":automergePatch",
+        ":automergeLinters",
+        ":automergeTesters",
+        ":automergeStableNonMajor",
+        ":automergeWeekly",
+      ],
+      matchDepTypes: ["devDependencies"],
+    }
+  ]
+}

--- a/ember-addon.json5
+++ b/ember-addon.json5
@@ -1,6 +1,7 @@
 {
   "extends": [
     "github>mainmatter/renovate-config:default.json5",
+    "github>mainmatter/renovate-config:automerge-dev.json5",
     ":pinOnlyDevDependencies"
   ],
   "packageRules": [


### PR DESCRIPTION
- Adds automerge configuration for ember-addons.
The intent is to allow automerging `devDependencies` on a weekly basis. 