### PR TITLE
chore(ember-addon): fix and change schedule to automerge daily

### DIFF
--- a/automerge-dev.json5
+++ b/automerge-dev.json5
@@ -6,7 +6,7 @@
         ":automergeLinters",
         ":automergeTesters",
         ":automergeStableNonMajor",
-        ":automergeWeekly",
+        "schedule:automergeNonOfficeHours",
       ],
       matchDepTypes: ["devDependencies"],
     }


### PR DESCRIPTION
- Fixes schedule option
:automerge schedules must be derived from `schedule`

- Change to outsideOfficeHours

https://docs.renovatebot.com/presets-schedule/#schedulenonofficehours